### PR TITLE
Feature/edit mood entry: Add support for editing mood entries (PUT /mood/{id})

### DIFF
--- a/backend/app/schemas/mood_entry.py
+++ b/backend/app/schemas/mood_entry.py
@@ -17,3 +17,10 @@ class MoodEntryResponse(BaseModel):
     reasons: Optional[List[str]] = None
     note: Optional[str] = None
     created_at: datetime
+
+
+class MoodEntryUpdate(BaseModel):
+    mood_score: Optional[int] = Field(default=None, ge=1, le=10)
+    emotions: Optional[List[str]] = None
+    reasons: Optional[List[str]] = None
+    note: Optional[str] = None


### PR DESCRIPTION
## מה כלול:
- יצירת סכמת MoodEntryUpdate עם שדות אופציונליים
- נתיב PUT /mood/{id} לעריכת רשומות של המשתמש בלבד
- אימות בעלות על הרשומה בעזרת fetch_link
- עדכון רשומה רק לפי שדות שנשלחו
- החזרת MoodEntryResponse לאחר השמירה
